### PR TITLE
add support for downloading and parsing the GeoNames cities15000 table

### DIFF
--- a/src/geonames/cities.clj
+++ b/src/geonames/cities.clj
@@ -32,8 +32,8 @@
   (if-not (comment? line)
     (-> (zipmap *header* (split line #"\t"))
         (update-in [:geoname-id] parse-integer)
-        ;; (update-in [:latitude] parse-integer)
-        ;; (update-in [:longitude] parse-integer)
+        (update-in [:latitude] parse-float)
+        (update-in [:longitude] parse-float)
         (update-in [:population] parse-integer)
         (replace-blank-values))))
 

--- a/src/geonames/util.clj
+++ b/src/geonames/util.clj
@@ -9,6 +9,10 @@
   (try (Integer/parseInt string)
        (catch NumberFormatException exception nil)))
 
+(defn parse-float [string]
+  (try (Float/parseFloat string)
+       (catch NumberFormatException exception nil)))
+
 (defn parse-list [string]
   (if string (map trim (split string #","))))
 

--- a/test/geonames/cities_test.clj
+++ b/test/geonames/cities_test.clj
@@ -9,6 +9,8 @@
     (let [san-francisco (first (filter #(= 5391959 (:geoname-id %)) cities))]
       (is (= 5391959 (:geoname-id san-francisco)))
       (is (= "San Francisco" (:name san-francisco)))
+      (is (= "-122.4" (format "%.1f" (:longitude san-francisco))))
+      (is (= "37.8" (format "%.1f" (:latitude san-francisco))))
       (is (= "US" (:country-code san-francisco)))
       (is (= "CA" (:admin1-code san-francisco)))
       (is (= "America/Los_Angeles" (:timezone san-francisco))))))


### PR DESCRIPTION
This table gives the name, country, population, etc.. of every city with a population over 15,000.

The code for this is almost exactly like the for the countries namespace, except the file needs to be unzipped and the column names are different.

Also bumped the minor version number to reflect this new functionality. Should not affect anything else.
